### PR TITLE
(fix): Don't Autoplay on Scroll

### DIFF
--- a/app/src/components/video/video.ts
+++ b/app/src/components/video/video.ts
@@ -70,6 +70,7 @@ export class MindsVideo{
   muted : boolean = true;
   autoplay : boolean = false;
   visibleplay : boolean = true;
+  wasvisible : boolean = true;
   loop : boolean = true;
   scroll_listener;
   poster:string = '';
@@ -277,6 +278,36 @@ export class MindsVideo{
     }
   }
 
+  wasFrameVisible(){
+     return this.wasvisible;
+  }
+ 
+  isFrameVisible(){
+    let visiblenow = (bounds.top < this.scroll.view.clientHeight && bounds.top + (this.scroll.view.clientHeight / 2) >= 0);
+    this.wasvisible = visiblenow;
+    return visiblenow;
+  }
+  
+  getFrameVisiblityStatus(){
+    return [this.wasFrameVisible(),this.isFrameVisible()];
+  }
+
+  hasFrameBecomeVisible(status){
+    return !status[0] && status[1];
+  }
+
+  hasFrameBecomeInvisible(status){
+    return status[0] && !status[1];
+  }
+
+  hasFrameStayedVisible(status){
+    return status[0] && status[1];
+  }
+
+  hasFrameStayedInvisible(status){
+    return !status[0] && !status[1]; 
+  }
+
   isVisible(){
     if(this.autoplay)
       return;
@@ -289,17 +320,20 @@ export class MindsVideo{
       return;
     }
     var bounds = this.element.getBoundingClientRect();
-    if(bounds.top < this.scroll.view.clientHeight && bounds.top + (this.scroll.view.clientHeight / 2) >= 0){
+    var visibilityStatus = this.getFrameVisibilityStatus();
+    if(this.hasFrameBecomeVisible(visibilityStatus)){
       if(this.element.paused == true){
         //console.log('[video]:: playing '  + this.src);
         this.element.play();
       }
-    } else {
+    } else if(this.hasFrameBecomeInvisible(visibilityStatus) || this.hasFrameStayedInvisible(visibilityStatus)){
       if(this.element.paused == false){
         this.element.muted = true;
         this.element.pause();
         //console.log('[video]:: pausing ' + this.src);
       }
+    } else {
+      
     }
       //console.log('[video]: checking visibility');
   }


### PR DESCRIPTION
Autoplay only as the video comes into view, allowing people to pause video without a scrolling motion replaying the video.