### PR TITLE
autosave drafts of statuses

### DIFF
--- a/app/src/controllers/newsfeed/poster/poster.html
+++ b/app/src/controllers/newsfeed/poster/poster.html
@@ -16,6 +16,7 @@
               name="message"
               [(ngModel)]="meta.message"
               (keyup)="getPostPreview(message)"
+              (keyup)="saveDraft(message)"
               placeholder="Enter your status here"
               i18n-placeholder
               [autoGrow]

--- a/app/src/controllers/newsfeed/poster/poster.ts
+++ b/app/src/controllers/newsfeed/poster/poster.ts
@@ -4,6 +4,7 @@ import { Client, Upload } from '../../../services/api';
 import { MindsActivityObject } from '../../../interfaces/entities';
 import { SessionFactory } from '../../../services/session';
 import { GunDB } from '../../../services/gun';
+import { Draft } from '../../../services/draft';
 
 import { AttachmentService } from '../../../services/attachment';
 import { ThirdPartyNetworksSelector } from '../../../components/third-party-networks/selector';
@@ -38,7 +39,7 @@ export class Poster {
 
   @ViewChild('thirdPartyNetworksSelector') thirdPartyNetworksSelector: ThirdPartyNetworksSelector;
 
-  constructor(public client: Client, public upload: Upload, public attachment: AttachmentService, public gun: GunDB){
+  constructor(public client: Client, public upload: Upload, public attachment: AttachmentService, public gun: GunDB, public draft: Draft){
     this.minds = window.Minds;
   }
 
@@ -59,11 +60,10 @@ export class Poster {
   }
 
   ngOnInit(){
-    var self = this;
-    var gun = self.gun;
-    gun.read('draft.status', function(message){
-      if(gun.draft && gun.draft.writing){ return }
-      self.meta.message = message;
+    var gun = this.gun;
+    gun.read('draft.status', (message) => {
+      if(this.draft && this.draft.writing){ return }
+      this.meta.message = message;
     });
   }
 
@@ -136,10 +136,10 @@ export class Poster {
 
   saveDraft(message){
     var gun = this.gun;
-    var draft = gun.draft || (gun.draft = {throttle: 120});
+    var draft = this.draft;
     clearTimeout(draft.debounce);
     draft.writing = true;
-    draft.debounce = setTimeout(function(){
+    draft.debounce = setTimeout(() => {
       gun.write('draft.status', message.value);
       draft.writing = false;
     }, draft.throttle);

--- a/app/src/services/draft.ts
+++ b/app/src/services/draft.ts
@@ -1,0 +1,14 @@
+export class Draft {
+
+	draft : any
+
+	throttle: 120
+
+	debounce: any
+
+	writing: boolean
+  
+  static _() {
+    return new Draft;
+  }
+}

--- a/app/src/services/gun.ts
+++ b/app/src/services/gun.ts
@@ -1,0 +1,20 @@
+var gun = window.Gun();
+
+export class GunDB {
+
+	draft : any
+
+	read(path : string, cb : any){
+		var a = path.split('.');
+		return gun.get(a[0]).path(a[1]).val(cb);
+	}
+
+	write(path : string, data : any){
+		var a = path.split('.');
+		return gun.get(a[0]).path(a[1]).put(data);
+	}
+  
+  static _() {
+    return new GunDB;
+  }
+}

--- a/app/src/services/gun.ts
+++ b/app/src/services/gun.ts
@@ -2,8 +2,6 @@ var gun = window.Gun();
 
 export class GunDB {
 
-	draft : any
-
 	read(path : string, cb : any){
 		var a = path.split('.');
 		return gun.get(a[0]).path(a[1]).val(cb);

--- a/app/src/services/providers.ts
+++ b/app/src/services/providers.ts
@@ -7,6 +7,7 @@ import { ScrollService } from './ux/scroll';
 import { SocketsService } from './sockets';
 import { Client, Upload } from './api';
 import { Storage } from './storage';
+import { GunDB } from './gun';
 import { SignupModalService } from '../components/modal/signup/service';
 import { CacheService } from './cache';
 import { HovercardService } from './hovercard';
@@ -47,6 +48,11 @@ export const MINDS_PROVIDERS : any[] = [
    {
      provide: Storage,
      useFactory: Storage._,
+     deps: []
+   },
+   {
+     provide: GunDB,
+     useFactory: GunDB._,
      deps: []
    },
    {

--- a/app/src/services/providers.ts
+++ b/app/src/services/providers.ts
@@ -8,6 +8,7 @@ import { SocketsService } from './sockets';
 import { Client, Upload } from './api';
 import { Storage } from './storage';
 import { GunDB } from './gun';
+import { Draft } from './draft';
 import { SignupModalService } from '../components/modal/signup/service';
 import { CacheService } from './cache';
 import { HovercardService } from './hovercard';
@@ -53,6 +54,11 @@ export const MINDS_PROVIDERS : any[] = [
    {
      provide: GunDB,
      useFactory: GunDB._,
+     deps: []
+   },
+   {
+     provide: Draft,
+     useFactory: Draft._,
      deps: []
    },
    {

--- a/app/typings/minds.d.ts
+++ b/app/typings/minds.d.ts
@@ -33,5 +33,6 @@ interface Window {
   io?: any;
   google?: any;
   twoOhSix?: any;
+  Gun?: any;
 }
 declare var window:Window;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "socket.io-client": "^1.4.5",
     "systemjs": "^0.19.18",
     "tinymce": "^4.2.6",
-    "zone.js": "0.6.23"
+    "zone.js": "0.6.23",
+    "gun": "github:amark/gun#0.5"
   },
   "devDependencies": {
     "async": "^1.4.2",

--- a/tools/config.ts
+++ b/tools/config.ts
@@ -93,6 +93,7 @@ export const PROD_NPM_DEPENDENCIES: InjectableDependency[] = normalizeDependenci
   // { src: 'angular2/es6/dev/src/testing/shims_for_IE.js', inject: 'shims' },
   { src: 'intl/dist/Intl.min.js', inject: 'shims' },
   { src: 'intl/locale-data/jsonp/en.js', inject: 'shims' },
+  { src: 'gun/gun.js', inject: 'shims' }
 ]);
 
 // Declare local files that needs to be injected


### PR DESCRIPTION
Things I don't like:

 - NPM is pointing to the latest and greatest but it is a github branch URL install. This should be changed to an NPM versioned one later.

 - Needed to add a `draft: any` to the service, which I'd like to find a cleaner way to handle options.

This works though! You can write a status message, reload the page, change pages, and it'll stick around.

Things I want to do next:

 - Add drafts to comments (already in progress).

 - Add drafts to blogs.

 - Cache the newsfeed for fast loading.

 - Hook into a `logout` lifecycle to `localStorage.clear()`