### PR TITLE
Fixed minor typo "will"

### DIFF
--- a/src/app/modules/wallet/tokens/addresses/addresses.component.html
+++ b/src/app/modules/wallet/tokens/addresses/addresses.component.html
@@ -3,7 +3,7 @@
 
   <p class="m-card--subtext">
     To receive OnChain payments from other channels (eg, from a Wire or a Boost), 
-    you will will need to let us know which address to direct these tokens to.
+    you will need to let us know which address to direct these tokens to.
   </p>
 
   <p class="m-card--subtext">


### PR DESCRIPTION
**After suggested update:** 
`To receive OnChain payments from other channels (eg, from a Wire or a Boost), you will need to let us know which address to direct these tokens to.`

**Before:** 
`To receive OnChain payments from other channels (eg, from a Wire or a Boost), you will will need to let us know which address to direct these tokens to.`