### PR TITLE
Hours api front end

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,6 +50,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { BlockchainModule } from './modules/blockchain/blockchain.module';
 import { BlockchainMarketingModule } from './modules/blockchain/marketing/marketing.module';
 import { BrandingModule } from './modules/branding/branding.module';
+import { HoursModule } from './modules/hours/hours.module';
 import { CommentsModule } from './modules/comments/comments.module';
 import { NodesMarketingModule } from './modules/nodes/nodes.module';
 import { JobsMarketingModule } from './modules/jobs/jobs.module';
@@ -105,6 +106,7 @@ import { JobsMarketingModule } from './modules/jobs/jobs.module';
     BlockchainMarketingModule,
     NodesMarketingModule,
     BrandingModule,
+    HoursModule,
     CommentsModule,
     JobsMarketingModule,
 

--- a/src/app/common/layout/topbar/navigation.component.html
+++ b/src/app/common/layout/topbar/navigation.component.html
@@ -77,4 +77,16 @@
     </a>
   </div>
 
+  <div>
+    <a class="m-topbar--navigation--item"
+      routerLink="/hours"
+      routerLinkActive="m-topbar--navigation--item-active"
+      title="Hours"
+      i18n-title="@@M_TOPBAR_HOURS"
+    >
+      <i class="material-icons">alarm</i>
+
+      <span class="m-topbar--navigation--text" i18n="@@M_TOPBAR_HOURS">Hours</span>
+    </a>
+  </div>
 </nav>

--- a/src/app/modules/hours/hours.component.html
+++ b/src/app/modules/hours/hours.component.html
@@ -1,0 +1,22 @@
+<div class="m-marketing m-hours">
+
+  <div class="m-marketing--header">
+
+    <div class="m-marketing--header-inner">
+      <h1 i18n="@@HOURS__TITLE">Hours</h1>
+      <h3 i18n="@@HOURS__SUBTITLE">How long you have been registered for</h3>
+    </div>
+
+  </div>
+
+  <div class="m-marketing--contents m-layout--row m-layout--wrap">
+    <div class="m-layout--cell">
+      You've been a non-paritsan (r)evolutionary for 
+      <strong>{{ (seconds/3600)| number:'1.0-0'}} hours</strong>
+      and <strong>{{ seconds % 3600/ 60 | number:'1.0-0'}} minutes</strong>.
+    </div>
+  </div>
+
+</div>
+
+<m-footer></m-footer>

--- a/src/app/modules/hours/hours.component.scss
+++ b/src/app/modules/hours/hours.component.scss
@@ -1,0 +1,23 @@
+@import "defaults";
+
+.m-hours {
+  .m-marketing--header {
+    background: #FFF;
+    padding: 100px 0 0;
+  }
+
+  .m-marketing--header-inner {
+    text-align: center;
+
+    h1 {
+      color: #444;
+    }
+
+    h3 {
+      color: #666;
+      padding-right: 0;
+    }
+
+  }
+
+}

--- a/src/app/modules/hours/hours.component.ts
+++ b/src/app/modules/hours/hours.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { Navigation as NavigationService } from '../../services/navigation';
+import { Session } from '../../services/session';
+import { MindsTitle } from '../../services/ux/title';
+import { Client } from '../../services/api';
+import { LoginReferrerService } from '../../services/login-referrer.service';
+
+@Component({
+  selector: 'm-hours',
+  templateUrl: 'hours.component.html'
+})
+
+export class HoursComponent {
+  minds;
+  seconds: number = 0;
+
+
+  constructor(
+    public client: Client,
+    public title: MindsTitle,
+  ) {
+  }
+
+  private timeout;
+
+  ngOnInit() {
+    this.minds = window.Minds;
+    this.title.setTitle('How many hours');
+    this.getHowManyHours();
+  }
+
+  async getHowManyHours() {
+    clearTimeout(this.timeout);
+
+    try {
+      //Could just use this.minds.user.time_created 
+      //But we're fetching data async from the api.
+      const response: any = await this.client.get(`api/v2/hours`);
+      let nowSecs = Math.floor(new Date().getTime() / 1000);
+      this.seconds = nowSecs - parseInt(response.seconds);
+      this.startCounter();
+    } catch (e) {
+        console.error(e);
+    }
+  }
+
+  startCounter() {
+    this.timeout = setTimeout(() => {
+      this.seconds += 1;
+      this.startCounter();
+    }, 1000);
+  }
+
+}

--- a/src/app/modules/hours/hours.module.ts
+++ b/src/app/modules/hours/hours.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { CommonModule as NgCommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { FormsModule as NgFormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { CommonModule } from '../../common/common.module';
+import { LegacyModule } from '../legacy/legacy.module';
+import { ModalsModule } from '../modals/modals.module';
+import { MindsFormsModule } from '../forms/forms.module';
+
+import { HoursComponent } from './hours.component';
+
+const routes: Routes = [
+  { path: 'hours', component: HoursComponent }
+];
+
+@NgModule({
+  imports: [
+    NgCommonModule,
+    RouterModule.forChild(routes),
+    NgFormsModule,
+    ReactiveFormsModule,
+    CommonModule,
+    LegacyModule,
+    ModalsModule,
+    MindsFormsModule,
+  ],
+  declarations: [
+    HoursComponent
+  ],
+  entryComponents: [
+    HoursComponent
+  ]
+})
+
+export class HoursModule {
+}


### PR DESCRIPTION
* Added a navigation route to the top bar using the material icons
* Cloned the branding page and condensed it a bit. Used the inherited m-marketing css and set a few specifiity rules.
* Wired up the component to take data from the hours api and then setatime out to update the tab.